### PR TITLE
Add syntax fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Example: `staging`
 
 **Required** Airbrake Project Repository.
 Can be set up in up in env `$AIRBRAKE_REPO`.
-Example: `https://github.com${{ github.repo }}`.
+Example: `https://github.com/${{ github.repository }}`.
 
 ### `revision`
 
@@ -52,7 +52,7 @@ with:
   project-id: ${{ env.AIRBRAKE_PROJECT_ID }}
   project-key: ${{ secret.AIRBRAKE_PROJECT_KEY }}
   environment: ${{ env.AIRBRAKE_ENVIRONMENT }}
-  repository: https://github.com${{ github.repo }}
+  repository: https://github.com/${{ github.repository }}
   revision: ${{ github.sha }}
   user: ${{ github.actor }}
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ usage() {
   exit 1
 }
 
-if [ -z "$PROJECT_ID" ] || [ -z "$PROJECT_KEY" ] || [ -z "$ENVIRONMENT" ] || [ -z "$REPOSITORY" ] || [ -z "$DEPLOY_USER" ]; then
+if [ -z "$PROJECT_ID" ] || [ -z "$PROJECT_KEY" ] || [ -z "$ENVIRONMENT" ] || [ -z "$REPOSITORY" ] || [ -z "$COMMIT_SHA" ] || [ -z "$DEPLOY_USER" ]; then
   echo "Missing required arguments!"
   usage
   exit 1
@@ -36,4 +36,4 @@ fi
 curl -X POST \
   -H "Content-Type: application/json" \
   -d '{"environment":"'"${ENVIRONMENT}"'","username":"'"${DEPLOY_USER}"'","repository":"'"${REPOSITORY}"'","revision":"'"${COMMIT_SHA}"'"}' \
-  "https://airbrake.io/api/v4/projects/${PROJECT_ID}/deploys?key=${PROJECT_KEY}"
+  "https://airbrake.io/api/v4/projects/${PROJECT_ID}/deploys?key=${PROJECT_KEY}" || exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ usage() {
   exit 1
 }
 
-if [[ -z $PROJECT_ID || -z $PROJECT_KEY || -z $ENVIRONMENT || -z $REPOSITORY || -z $DEPLOY_USER ]]; then
+if [ -z "$PROJECT_ID" ] || [ -z "$PROJECT_KEY" ] || [ -z "$ENVIRONMENT" ] || [ -z "$REPOSITORY" ] || [ -z "$DEPLOY_USER" ]; then
   echo "Missing required arguments!"
   usage
   exit 1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,5 +35,5 @@ fi
 
 curl -X POST \
   -H "Content-Type: application/json" \
-  -d '{"environment":"'${ENVIRONMENT}'","username":"'${DEPLOY_USER}'","repository":"'${REPOSITORY}'","revision":"'${COMMIT_SHA}'"}' \
+  -d '{"environment":"'"${ENVIRONMENT}"'","username":"'"${DEPLOY_USER}"'","repository":"'"${REPOSITORY}"'","revision":"'"${COMMIT_SHA}"'"}' \
   "https://airbrake.io/api/v4/projects/${PROJECT_ID}/deploys?key=${PROJECT_KEY}"

--- a/example_usage.yml
+++ b/example_usage.yml
@@ -25,7 +25,7 @@
 #         id: airbrake-deploy
 #         with:
 #           project-key: ${{ secrets.AIRBRAKE_PROJECT_KEY }}
-#           repository: https://github.com${{ github.repo }}
+#           repository: https://github.com/${{ github.repository }}
 #           revision: ${{ github.sha }}
 #           user: ${{ github.actor }}
 #       - name: Get the deploy response


### PR DESCRIPTION
- Change `github.repo` to `github.repository`
- Make required arguments check POSIX sh compliant (fixes `sh: -z: unknown operand`, [SC3010](https://www.shellcheck.net/wiki/SC3010))
- Add  `|| exit 1` to curl command, otherwise it can fail silently
- Fix curl command to handle variables with spaces in name ([SC2026](https://www.shellcheck.net/wiki/SC2026))